### PR TITLE
BS-13367 Contract "integer" cannot be mapped to BDM "integer"

### DIFF
--- a/bundles/plugins/org.bonitasoft.studio.common/src/org/bonitasoft/studio/common/emf/tools/ExpressionHelper.java
+++ b/bundles/plugins/org.bonitasoft.studio.common/src/org/bonitasoft/studio/common/emf/tools/ExpressionHelper.java
@@ -63,7 +63,7 @@ public class ExpressionHelper {
         returnTypeForInputType.put(ContractInputType.TEXT, String.class.getName());
         returnTypeForInputType.put(ContractInputType.BOOLEAN, Boolean.class.getName());
         returnTypeForInputType.put(ContractInputType.DATE, Date.class.getName());
-        returnTypeForInputType.put(ContractInputType.INTEGER, Long.class.getName());
+        returnTypeForInputType.put(ContractInputType.INTEGER, Integer.class.getName());
         returnTypeForInputType.put(ContractInputType.DECIMAL, Double.class.getName());
         returnTypeForInputType.put(ContractInputType.COMPLEX, Map.class.getName());
         returnTypeForInputType.put(ContractInputType.FILE, FileInputValue.class.getName());

--- a/bundles/plugins/org.bonitasoft.studio.contract/src-test/java/org/bonitasoft/studio/contract/core/mapping/SimpleFieldToContractInputMappingTest.java
+++ b/bundles/plugins/org.bonitasoft.studio.contract/src-test/java/org/bonitasoft/studio/contract/core/mapping/SimpleFieldToContractInputMappingTest.java
@@ -63,7 +63,7 @@ public class SimpleFieldToContractInputMappingTest {
 
         final ContractInput input = fieldToContractInputMapping.toContractInput();
 
-        ContractInputAssert.assertThat(input).hasName("timeStamp").hasType(ContractInputType.INTEGER).hasNoInputs();
+        ContractInputAssert.assertThat(input).hasName("timeStamp").hasType(ContractInputType.TEXT).hasNoInputs();
     }
 
     @Test

--- a/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/core/mapping/SimpleFieldToContractInputMapping.java
+++ b/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/core/mapping/SimpleFieldToContractInputMapping.java
@@ -41,7 +41,7 @@ public class SimpleFieldToContractInputMapping extends FieldToContractInputMappi
             case INTEGER:
                 return ContractInputType.INTEGER;
             case LONG:
-                return ContractInputType.INTEGER;
+                return ContractInputType.TEXT;
             case DOUBLE:
                 return ContractInputType.DECIMAL;
             case FLOAT:


### PR DESCRIPTION
Map Contract Input integer to a java.lang.Integer
When generating a contract from a business data with a long field, use a
Text input.