### PR TITLE
Revert "BS-14434 Disable Marck occurence preference"

### DIFF
--- a/bundles/plugins/org.bonitasoft.studio.preferences/META-INF/MANIFEST.MF
+++ b/bundles/plugins/org.bonitasoft.studio.preferences/META-INF/MANIFEST.MF
@@ -23,8 +23,7 @@ Require-Bundle: org.eclipse.ui,
  org.junit;bundle-version="4.11.0";resolution:=optional,
  org.mockito;bundle-version="1.9.5";resolution:=optional,
  assertj-core;bundle-version="1.5.0";resolution:=optional,
- org.eclipse.debug.ui,
- org.eclipse.jdt.ui
+ org.eclipse.debug.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/bundles/plugins/org.bonitasoft.studio.preferences/src/org/bonitasoft/studio/preferences/PreferenceInitializer.java
+++ b/bundles/plugins/org.bonitasoft.studio.preferences/src/org/bonitasoft/studio/preferences/PreferenceInitializer.java
@@ -24,7 +24,6 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.preferences.IDebugPreferenceConstants;
-import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IWorkbenchPreferenceConstants;
@@ -72,9 +71,6 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer impleme
         getAPIPreferenceStore().setValue(IWorkbenchPreferenceConstants.DISABLE_OPEN_EDITOR_IN_PLACE, true);
 
         initDefaultDebugPreferences();
-
-        final IPreferenceStore jdtUIStore = PreferenceConstants.getPreferenceStore();
-        jdtUIStore.setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, Boolean.FALSE);
     }
 
     protected IPreferenceStore getAPIPreferenceStore() {


### PR DESCRIPTION
Reverts bonitasoft/bonita-studio#308
;due to failing test
org.bonitasoft.studio.preferences.PreferenceInitializerTest.testLegacyModeDeactivatedByDefault

Failing for the past 1 build (Since Failed#25 )
Took 0.32 sec.
Stacktrace

java.lang.NullPointerException: null
	at org.eclipse.jdt.ui.PreferenceConstants.getPreferenceStore(PreferenceConstants.java:3980)
	at org.bonitasoft.studio.preferences.PreferenceInitializer.initializeDefaultPreferences(PreferenceInitializer.java:76)
	at org.bonitasoft.studio.preferences.PreferenceInitializerTest.testLegacyModeDeactivatedByDefault(PreferenceInitializerTest.java:46)