### PR TITLE
BS-14823: workaround to have "select all" button working

### DIFF
--- a/bundles/plugins/org.bonitasoft.studio.common.repository/src/org/bonitasoft/studio/common/repository/ui/wizard/ExportRepositoryWizardPage.java
+++ b/bundles/plugins/org.bonitasoft.studio.common.repository/src/org/bonitasoft/studio/common/repository/ui/wizard/ExportRepositoryWizardPage.java
@@ -1,6 +1,6 @@
 /**
- * Copyright (C) 2012-2014 Bonitasoft S.A.
- * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
+ * Copyright (C) 2012-2015 Bonitasoft S.A.
+ * Bonitasoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2.0 of the License, or
@@ -180,6 +180,7 @@ public class ExportRepositoryWizardPage extends WizardPage {
 
             @Override
             public void widgetSelected(final SelectionEvent e) {
+                checkedElementsObservable.clear();
                 final ITreeContentProvider provider = (ITreeContentProvider) treeViewer.getContentProvider();
                 checkedElementsObservable.addAll(Arrays.asList(provider.getElements(stores)));
             }


### PR DESCRIPTION
If nodes are grayed (at least one child checked but not all), clicking
select all left it as grayed and don't checked the all the children

Might worth writing an UI tests to ensure non-regression