### PR TITLE
fix(BPMN Export) Use participant id at export.

### DIFF
--- a/bundles/plugins/org.bonitasoft.studio.exporter/src/org/bonitasoft/studio/exporter/bpmn/transfo/BonitaToBPMN.java
+++ b/bundles/plugins/org.bonitasoft.studio.exporter/src/org/bonitasoft/studio/exporter/bpmn/transfo/BonitaToBPMN.java
@@ -532,7 +532,7 @@ public class BonitaToBPMN implements IBonitaTransformer {
 
         //create graphic process
         final BPMNShape processShape = createBPMNShape(childPart);
-        processShape.setBpmnElement(QName.valueOf(bpmnProcess.getId()));
+        processShape.setBpmnElement(QName.valueOf(participant.getId()));
         final IFigure bonitaPoolFigure = childPart.getFigure();
         final Rectangle bounds = getAbsoluteLabelBounds(bonitaPoolFigure);
         final Bounds laneBounds = DcFactory.eINSTANCE.createBounds();


### PR DESCRIPTION
Use the participant id instead of the process id for the bpmnElement
reference in the Shape.