### PR TITLE
fix(Repository) Repository creation

### DIFF
--- a/bundles/plugins/org.bonitasoft.studio.common.repository/src-test/java/org/bonitasoft/studio/common/repository/core/ProjectManifestFactoryTest.java
+++ b/bundles/plugins/org.bonitasoft.studio.common.repository/src-test/java/org/bonitasoft/studio/common/repository/core/ProjectManifestFactoryTest.java
@@ -93,4 +93,23 @@ public class ProjectManifestFactoryTest {
                 entry("Require-Bundle", "javax.persistence;bundle-version=\"2.0.3\"," + System.lineSeparator() + " org.bonitasoft.studio.console.libs"),
                 entry("Bundle-RequiredExecutionEnvironment", "JavaSE-1.7"));
     }
+
+    @Test
+    public void should_use_a_fallback_symbolic_name_if_project_name_cannot_be_converted_to_a_valid_java_identifiers() throws Exception {
+        //When
+        final ProjectManifestFactory projectManifestFactory = spy(new ProjectManifestFactory());
+        doReturn("org.bonitasoft.studio.console.libs").when(projectManifestFactory).engineBundleSymbolicName();
+        final Map<String, String> manifestHeaders = projectManifestFactory.createManifestHeaders("0001");
+
+        //Then
+        assertThat(manifestHeaders).contains(
+                entry("Manifest-Version", "1.0"),
+                entry("Bundle-ManifestVersion", "2"),
+                entry("Bundle-Name", "0001"),
+                entry("Bundle-SymbolicName", "org.bonitasoft.studio.myextensions"),
+                entry("Bundle-Version", "1.0.0.qualifier"),
+                entry("Bundle-Vendor", "Bonitasoft S.A."),
+                entry("Require-Bundle", "javax.persistence;bundle-version=\"2.0.3\"," + System.lineSeparator() + " org.bonitasoft.studio.console.libs"),
+                entry("Bundle-RequiredExecutionEnvironment", "JavaSE-1.7"));
+    }
 }

--- a/bundles/plugins/org.bonitasoft.studio.common.repository/src/org/bonitasoft/studio/common/repository/core/ProjectManifestFactory.java
+++ b/bundles/plugins/org.bonitasoft.studio.common.repository/src/org/bonitasoft/studio/common/repository/core/ProjectManifestFactory.java
@@ -38,6 +38,7 @@ public class ProjectManifestFactory {
 
     private static final String MANIFEST_MF_FILE_NAME = "MANIFEST.MF";
     private static final String META_INF_FOLDER_NAME = "META-INF";
+    private static final String DEFAULT_SYMBOLIC_NAME = "org.bonitasoft.studio.myextensions";
 
     public void createProjectManifest(final IProject project, final IProgressMonitor monitor) throws CoreException {
         final IFolder metaInf = project.getFolder(META_INF_FOLDER_NAME);
@@ -64,7 +65,11 @@ public class ProjectManifestFactory {
         headers.put(ManifestUtils.MANIFEST_VERSION, "1.0");
         headers.put(org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION, "2");
         headers.put(org.osgi.framework.Constants.BUNDLE_NAME, projectName);
-        headers.put(org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME, toJavaIdentifier(projectName, false));
+        String symbolicName = toJavaIdentifier(projectName, false);
+        if (symbolicName == null || symbolicName.isEmpty()) {
+            symbolicName = DEFAULT_SYMBOLIC_NAME;
+        }
+        headers.put(org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME, symbolicName);
         headers.put(org.osgi.framework.Constants.BUNDLE_VERSION, "1.0.0.qualifier");
         headers.put(org.osgi.framework.Constants.BUNDLE_VENDOR, "Bonitasoft S.A.");
         headers.put(org.osgi.framework.Constants.BUNDLE_REQUIREDEXECUTIONENVIRONMENT, "JavaSE-1.7");


### PR DESCRIPTION
Use a fallback symbolic name when repository name cannot be converted
into a java valid identifiers (eg: digits only )

fixes BS-15497