### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/all-in-one/installer/installer_project_template.xml
+++ b/all-in-one/installer/installer_project_template.xml
@@ -266,7 +266,7 @@
         </runProgram>
         <launchBrowser>
             <show>0</show>
-            <url>http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=126&amp;bos_redirect_product=bos&amp;bos_version=${product_version}&amp;os=${platform_name}&amp;arch=@os_arch@&amp;edition=community&amp;lang=${installation_language_code}&amp;utm_source=bonita_wizard&amp;utm_medium=referral&amp;utm_campaign=bonita_install</url>
+            <url>http://www.ofelia.com/bos_redirect.php?bos_redirect_id=126&amp;bos_redirect_product=bos&amp;bos_version=${product_version}&amp;os=${platform_name}&amp;arch=@os_arch@&amp;edition=community&amp;lang=${installation_language_code}&amp;utm_source=bonita_wizard&amp;utm_medium=referral&amp;utm_campaign=bonita_install</url>
         </launchBrowser>
     </finalPageActionList>
 
@@ -408,7 +408,7 @@
               <explanation>${msg(antivirus.detected.message)}</explanation>
               <clickedActionList>
                 <launchBrowser>
-                  <url>http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=714&amp;bos_redirect_product=bos&amp;bos_version=@product.version@</url>
+                  <url>http://www.ofelia.com/bos_redirect.php?bos_redirect_id=714&amp;bos_redirect_product=bos&amp;bos_version=@product.version@</url>
                 </launchBrowser>
               </clickedActionList>
             </linkParameter>

--- a/bundles/plugins/org.bonitasoft.studio.application.tests/src/org/bonitasoft/studio/application/statistics/DefaultStatisticsManagerTest.java
+++ b/bundles/plugins/org.bonitasoft.studio.application.tests/src/org/bonitasoft/studio/application/statistics/DefaultStatisticsManagerTest.java
@@ -69,7 +69,7 @@ class DefaultStatisticsManagerTest {
         var request = requestCaptor.getValue();
         assertThat(request.uri())
                 .hasToString(String.format(
-                        "https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=765&bos_redirect_major_version=%s&bos_redirect_minor_version=%s&bos_redirect_product=bos&groupId=g&artifactId=a&version=v&extensionType=connector",
+                        "https://www.ofelia.com/bos_redirect.php?bos_redirect_id=765&bos_redirect_major_version=%s&bos_redirect_minor_version=%s&bos_redirect_product=bos&groupId=g&artifactId=a&version=v&extensionType=connector",
                         ProductVersion.minorVersion(),
                         ProductVersion.maintenanceVersion()));
     }

--- a/bundles/plugins/org.bonitasoft.studio.application/src/org/bonitasoft/studio/application/actions/ShowHelpCommand.java
+++ b/bundles/plugins/org.bonitasoft.studio.application/src/org/bonitasoft/studio/application/actions/ShowHelpCommand.java
@@ -46,7 +46,7 @@ public class ShowHelpCommand extends AbstractHandler {
             if (globalProperties != null) {
                 url = globalProperties.getProperty(HELP_URL_PROPERTY);
             } else {
-                url = "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=74";
+                url = "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=74";
             }
             url = url.concat("&").concat(majorVersion());
             IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport()

--- a/bundles/plugins/org.bonitasoft.studio.common/src/org/bonitasoft/studio/common/RedirectURLBuilder.java
+++ b/bundles/plugins/org.bonitasoft.studio.common/src/org/bonitasoft/studio/common/RedirectURLBuilder.java
@@ -25,7 +25,7 @@ import org.bonitasoft.studio.common.log.BonitaStudioLog;
 
 public class RedirectURLBuilder {
 
-    private static final String BASE_URL = "https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=";
+    private static final String BASE_URL = "https://www.ofelia.com/bos_redirect.php?bos_redirect_id=";
     private static final String LOCATION_HEADER = "Location";
     
     public static String create(String redirectId) {

--- a/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/core/operation/CreateFormFromContractOperation.java
+++ b/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/core/operation/CreateFormFromContractOperation.java
@@ -58,7 +58,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public class CreateFormFromContractOperation extends CreateUIDArtifactOperation {
 
     private static final String FORM_GENERATION_DOCUMENTATION_LINK = String.format(
-            "https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=685&bos_redirect_product=bos&bos_redirect_major_version=%s&bos_redirect_minor_version=0",
+            "https://www.ofelia.com/bos_redirect.php?bos_redirect_id=685&bos_redirect_product=bos&bos_redirect_major_version=%s&bos_redirect_minor_version=0",
             ProductVersion.minorVersion());
 
     private Contract contract;

--- a/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/ui/wizard/CreateContractInputFromBusinessObjectWizardPage.java
+++ b/bundles/plugins/org.bonitasoft.studio.contract/src/org/bonitasoft/studio/contract/ui/wizard/CreateContractInputFromBusinessObjectWizardPage.java
@@ -154,7 +154,7 @@ public class CreateContractInputFromBusinessObjectWizardPage extends WizardPage 
     private void openBrowser(String redirectId) {
         try {
             new OpenBrowserOperation(new URL(String.format(
-                    "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=%s&bos_redirect_product=bos&bos_redirect_major_version=%s",
+                    "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=%s&bos_redirect_product=bos&bos_redirect_major_version=%s",
                     redirectId,
                     ProductVersion.minorVersion()))).execute();
         } catch (MalformedURLException e) {

--- a/bundles/plugins/org.bonitasoft.studio.groovy.ui/src/org/bonitasoft/studio/groovy/ui/providers/GroovyScriptExpressionEditor.java
+++ b/bundles/plugins/org.bonitasoft.studio.groovy.ui/src/org/bonitasoft/studio/groovy/ui/providers/GroovyScriptExpressionEditor.java
@@ -136,7 +136,7 @@ public class GroovyScriptExpressionEditor extends SelectionAwareExpressionEditor
         try {
             EXPRESSION_AND_SCRIPTS_URL = new URL(
                     String.format(
-                            "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=678&bos_redirect_product=bos&bos_redirect_major_version=%s",
+                            "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=678&bos_redirect_product=bos&bos_redirect_major_version=%s",
                             ProductVersion.minorVersion()));
         } catch (MalformedURLException e) {
             BonitaStudioLog.error(e);

--- a/bundles/plugins/org.bonitasoft.studio.intro/src/org/bonitasoft/studio/intro/content/IntroContentProvider.java
+++ b/bundles/plugins/org.bonitasoft.studio.intro/src/org/bonitasoft/studio/intro/content/IntroContentProvider.java
@@ -164,7 +164,7 @@ public class IntroContentProvider implements IIntroXHTMLContentProvider {
 
     public static String redirectUrl(String redirectId, String product, boolean includeSEOParams) {
         return String.format(
-                "https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=%s&bos_redirect_product=%s&bos_redirect_major_version=%s&bos_redirect_minor_version=%s%s",
+                "https://www.ofelia.com/bos_redirect.php?bos_redirect_id=%s&bos_redirect_product=%s&bos_redirect_major_version=%s&bos_redirect_minor_version=%s%s",
                 redirectId,
                 product,
                 ProductVersion.minorVersion(),

--- a/bundles/plugins/org.bonitasoft.studio.intro/src/org/bonitasoft/studio/intro/content/LogoContentProvider.java
+++ b/bundles/plugins/org.bonitasoft.studio.intro/src/org/bonitasoft/studio/intro/content/LogoContentProvider.java
@@ -57,7 +57,7 @@ public class LogoContentProvider implements DOMContentProvider {
                 "http://org.eclipse.ui.intro/runAction?pluginId=org.bonitasoft.studio.intro&class=%s&url=%s",
                 OpenInExternalBrowserIntroAction.class.getName(),
                 URLEncoder.encode(String.format(
-                        "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=%s&&bos_redirect_product=bos&bos_redirect_major_version=%s&currentVersion&bos_redirect_minor_version=0",
+                        "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=%s&&bos_redirect_product=bos&bos_redirect_major_version=%s&currentVersion&bos_redirect_minor_version=0",
                         id, currentVersion), "UTF-8"));
     }
 

--- a/bundles/plugins/org.bonitasoft.studio.properties/src/org/bonitasoft/studio/properties/sections/timer/cron/CronEditor.java
+++ b/bundles/plugins/org.bonitasoft.studio.properties/src/org/bonitasoft/studio/properties/sections/timer/cron/CronEditor.java
@@ -173,7 +173,7 @@ public class CronEditor extends Composite {
     };
 
     private static final String CRON_DOCUMENTATION_URL = String.format(
-            "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=669&bos_redirect_product=bos&bos_redirect_major_version=%s",
+            "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=669&bos_redirect_product=bos&bos_redirect_major_version=%s",
             ProductVersion.minorVersion());
 
     private CronExpression cronExpression;

--- a/bundles/plugins/org.bonitasoft.studio.rest.api.extension/src/org/bonitasoft/studio/extensions/wizard/NewExtensionWizard.java
+++ b/bundles/plugins/org.bonitasoft.studio.rest.api.extension/src/org/bonitasoft/studio/extensions/wizard/NewExtensionWizard.java
@@ -40,7 +40,7 @@ import org.eclipse.jface.wizard.Wizard;
  */
 public class NewExtensionWizard extends Wizard {
 
-    private static final String DOC_URL_TEMPLATE = "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=%1$s&bos_redirect_product=bos&bos_redirect_major_version=%2$s&bos_redirect_minor_version=";
+    private static final String DOC_URL_TEMPLATE = "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=%1$s&bos_redirect_product=bos&bos_redirect_major_version=%2$s&bos_redirect_minor_version=";
 
     private final ArtifactType artifactType;
     private final ExtensionRepositoryStore repositoryStore;

--- a/bundles/plugins/org.bonitasoft.studio.team.git/src/org/bonitasoft/studio/team/git/ui/wizard/FirstPushAbortedDialog.java
+++ b/bundles/plugins/org.bonitasoft.studio.team.git/src/org/bonitasoft/studio/team/git/ui/wizard/FirstPushAbortedDialog.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Shell;
 
 public class FirstPushAbortedDialog extends MessageDialog {
 
-    private static final String DOCUMENTATION_GIT_URL = "http://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=672&bos_redirect_product=bos&bos_redirect_major_version=%s";
+    private static final String DOCUMENTATION_GIT_URL = "http://www.ofelia.com/bos_redirect.php?bos_redirect_id=672&bos_redirect_product=bos&bos_redirect_major_version=%s";
 
     public FirstPushAbortedDialog(Shell parentShell) {
         super(parentShell, Messages.shareRepositoryProgressTitle, null, null, 0,

--- a/tests/org.bonitasoft.studio.tests/resources/invalid_uid_workspace/web_widgets/pbTabsContainer/help.html
+++ b/tests/org.bonitasoft.studio.tests/resources/invalid_uid_workspace/web_widgets/pbTabsContainer/help.html
@@ -4,7 +4,7 @@
         <p translate>Using the Vertical Display property, it is possible to display tabs vertically or horizontally.</p>
         <p class="alert alert-info" translate>
             To Display the tab vertically and on the left of the content, you can read this <a
-            href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=712&bos_redirect_product=bos&bos_redirect_major_version=7.10">how
+            href="https://www.ofelia.com/bos_redirect.php?bos_redirect_id=712&bos_redirect_product=bos&bos_redirect_major_version=7.10">how
             to learn more about customization</a>
         </p>
         <p translate>The Display Type property allows you to customize the tabs style ('tabs' or 'pills').</p>

--- a/tests/org.bonitasoft.studio.tests/resources/valid_uid_workspace/web_widgets/pbTabsContainer/help.html
+++ b/tests/org.bonitasoft.studio.tests/resources/valid_uid_workspace/web_widgets/pbTabsContainer/help.html
@@ -4,7 +4,7 @@
         <p translate>Using the Vertical Display property, it is possible to display tabs vertically or horizontally.</p>
         <p class="alert alert-info" translate>
             To Display the tab vertically and on the left of the content, you can read this <a
-            href="https://www.bonitasoft.com/bos_redirect.php?bos_redirect_id=712&bos_redirect_product=bos&bos_redirect_major_version=7.10">how
+            href="https://www.ofelia.com/bos_redirect.php?bos_redirect_id=712&bos_redirect_product=bos&bos_redirect_major_version=7.10">how
             to learn more about customization</a>
         </p>
         <p translate>The Display Type property allows you to customize the tabs style ('tabs' or 'pills').</p>


### PR DESCRIPTION
## Summary

- Replace all `www.bonitasoft.com/bos_redirect.php` URLs with `www.ofelia.com/bos_redirect.php` across the codebase
- IT has confirmed the redirect service is live at `www.ofelia.com/bos_redirect.php` (verified returning 301)
- 14 files updated across Java sources, XML installer config, and HTML resources

## Files changed

- `bundles/plugins/org.bonitasoft.studio.intro/.../LogoContentProvider.java`
- `bundles/plugins/org.bonitasoft.studio.common/.../RedirectURLBuilder.java`
- `bundles/plugins/org.bonitasoft.studio.application/.../ShowHelpCommand.java`
- `all-in-one/installer/installer_project_template.xml`
- `bundles/plugins/org.bonitasoft.studio.team.git/.../FirstPushAbortedDialog.java`
- `bundles/plugins/org.bonitasoft.studio.intro/.../IntroContentProvider.java`
- `bundles/plugins/org.bonitasoft.studio.rest.api.extension/.../NewExtensionWizard.java`
- `bundles/plugins/org.bonitasoft.studio.contract/.../CreateFormFromContractOperation.java`
- `bundles/plugins/org.bonitasoft.studio.groovy.ui/.../GroovyScriptExpressionEditor.java`
- `bundles/plugins/org.bonitasoft.studio.contract/.../CreateContractInputFromBusinessObjectWizardPage.java`
- `bundles/plugins/org.bonitasoft.studio.properties/.../CronEditor.java`
- `tests/.../valid_uid_workspace/web_widgets/pbTabsContainer/help.html`
- `bundles/plugins/org.bonitasoft.studio.application.tests/.../DefaultStatisticsManagerTest.java`
- `tests/.../invalid_uid_workspace/web_widgets/pbTabsContainer/help.html`

## Test plan

- [ ] Verify redirect links in Studio UI still resolve correctly via `www.ofelia.com/bos_redirect.php`
- [ ] Smoke-test help/documentation links in Studio (Help menu, intro page, contract/form wizards)
- [ ] Confirm installer XML generates correct URLs

Part of the Bonitasoft to Ofelia rebranding initiative.